### PR TITLE
feat(server): persona-grounded chat server

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.3.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.nerw</groupId>
+    <artifactId>ancestor-chat</artifactId>
+    <version>0.1.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial</groupId>
+            <artifactId>sqlite-jdbc</artifactId>
+            <version>3.46.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>3.9.2</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <finalName>ancestor-chat</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*Test.java</include>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/server/src/main/java/com/nerw/ancestor/AncestorServer.java
+++ b/server/src/main/java/com/nerw/ancestor/AncestorServer.java
@@ -1,0 +1,11 @@
+package com.nerw.ancestor;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AncestorServer {
+    public static void main(String[] args) {
+        SpringApplication.run(AncestorServer.class, args);
+    }
+}

--- a/server/src/main/java/com/nerw/ancestor/ancestor/Ancestor.java
+++ b/server/src/main/java/com/nerw/ancestor/ancestor/Ancestor.java
@@ -1,0 +1,19 @@
+package com.nerw.ancestor.ancestor;
+
+import java.util.List;
+
+public record Ancestor(
+        String id,
+        String name,
+        String relation,
+        Integer birthYear,
+        Integer deathYear,
+        String birthplace,
+        String profession,
+        String language,
+        List<String> lifeEvents,
+        List<String> personalityTraits,
+        List<String> historicalContext,
+        String photoUrl
+) {
+}

--- a/server/src/main/java/com/nerw/ancestor/ancestor/AncestorController.java
+++ b/server/src/main/java/com/nerw/ancestor/ancestor/AncestorController.java
@@ -1,0 +1,92 @@
+package com.nerw.ancestor.ancestor;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/ancestors")
+public class AncestorController {
+
+    private final AncestorRepository repo;
+
+    public AncestorController(AncestorRepository repo) {
+        this.repo = repo;
+    }
+
+    public record AncestorRequest(
+            String name,
+            String relation,
+            @JsonProperty("birth_year") Integer birthYear,
+            @JsonProperty("death_year") Integer deathYear,
+            String birthplace,
+            String profession,
+            String language,
+            @JsonProperty("life_events") List<String> lifeEvents,
+            @JsonProperty("personality_traits") List<String> personalityTraits,
+            @JsonProperty("historical_context") List<String> historicalContext,
+            @JsonProperty("photo_url") String photoUrl
+    ) {
+        Ancestor toAncestor() {
+            return new Ancestor(null, name, relation, birthYear, deathYear,
+                    birthplace, profession, language,
+                    lifeEvents, personalityTraits, historicalContext, photoUrl);
+        }
+    }
+
+    public record AncestorResponse(
+            String id,
+            String name,
+            String relation,
+            @JsonProperty("birth_year") Integer birthYear,
+            @JsonProperty("death_year") Integer deathYear,
+            String birthplace,
+            String profession,
+            String language,
+            @JsonProperty("life_events") List<String> lifeEvents,
+            @JsonProperty("personality_traits") List<String> personalityTraits,
+            @JsonProperty("historical_context") List<String> historicalContext,
+            @JsonProperty("photo_url") String photoUrl
+    ) {
+        static AncestorResponse from(Ancestor a) {
+            return new AncestorResponse(
+                    a.id(), a.name(), a.relation(), a.birthYear(), a.deathYear(),
+                    a.birthplace(), a.profession(), a.language(),
+                    a.lifeEvents(), a.personalityTraits(), a.historicalContext(),
+                    a.photoUrl());
+        }
+    }
+
+    @PostMapping
+    public ResponseEntity<AncestorResponse> create(@RequestBody AncestorRequest req) {
+        Ancestor saved = repo.create(req.toAncestor());
+        return ResponseEntity.status(HttpStatus.CREATED).body(AncestorResponse.from(saved));
+    }
+
+    @GetMapping
+    public List<AncestorResponse> list() {
+        return repo.findAll().stream().map(AncestorResponse::from).toList();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AncestorResponse> get(@PathVariable String id) {
+        return repo.findById(id)
+                .map(a -> ResponseEntity.ok(AncestorResponse.from(a)))
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable String id) {
+        boolean removed = repo.delete(id);
+        return removed ? ResponseEntity.noContent().build() : ResponseEntity.notFound().build();
+    }
+}

--- a/server/src/main/java/com/nerw/ancestor/ancestor/AncestorRepository.java
+++ b/server/src/main/java/com/nerw/ancestor/ancestor/AncestorRepository.java
@@ -1,0 +1,208 @@
+package com.nerw.ancestor.ancestor;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Repository;
+
+import java.io.File;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public class AncestorRepository {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final TypeReference<List<String>> STR_LIST = new TypeReference<>() {};
+
+    private final String jdbcUrl;
+
+    public AncestorRepository(@Value("${db.path}") String dbPath) {
+        this.jdbcUrl = buildJdbcUrl(dbPath);
+    }
+
+    static String buildJdbcUrl(String dbPath) {
+        if (dbPath == null || dbPath.isBlank() || ":memory:".equals(dbPath)) {
+            return "jdbc:sqlite::memory:";
+        }
+        File f = new File(dbPath);
+        File parent = f.getParentFile();
+        if (parent != null && !parent.exists()) {
+            parent.mkdirs();
+        }
+        return "jdbc:sqlite:" + dbPath;
+    }
+
+    @PostConstruct
+    public void init() {
+        try (Connection c = connect(); Statement s = c.createStatement()) {
+            s.execute("""
+                    CREATE TABLE IF NOT EXISTS ancestors (
+                        id TEXT PRIMARY KEY,
+                        name TEXT NOT NULL,
+                        relation TEXT,
+                        birth_year INTEGER,
+                        death_year INTEGER,
+                        birthplace TEXT,
+                        profession TEXT,
+                        language TEXT,
+                        life_events TEXT,
+                        personality_traits TEXT,
+                        historical_context TEXT,
+                        photo_url TEXT
+                    )
+                    """);
+            s.execute("""
+                    CREATE TABLE IF NOT EXISTS messages (
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        ancestor_id TEXT NOT NULL,
+                        role TEXT NOT NULL,
+                        content TEXT NOT NULL,
+                        created_at TEXT NOT NULL
+                    )
+                    """);
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to init DB schema", e);
+        }
+    }
+
+    public Connection connect() throws SQLException {
+        return DriverManager.getConnection(jdbcUrl);
+    }
+
+    public Ancestor create(Ancestor a) {
+        String id = a.id() != null ? a.id() : UUID.randomUUID().toString();
+        Ancestor toSave = new Ancestor(
+                id, a.name(), a.relation(), a.birthYear(), a.deathYear(),
+                a.birthplace(), a.profession(), a.language(),
+                a.lifeEvents(), a.personalityTraits(), a.historicalContext(),
+                a.photoUrl()
+        );
+        try (Connection c = connect();
+             PreparedStatement ps = c.prepareStatement(
+                     "INSERT INTO ancestors VALUES (?,?,?,?,?,?,?,?,?,?,?,?)")) {
+            ps.setString(1, toSave.id());
+            ps.setString(2, toSave.name());
+            ps.setString(3, toSave.relation());
+            setNullableInt(ps, 4, toSave.birthYear());
+            setNullableInt(ps, 5, toSave.deathYear());
+            ps.setString(6, toSave.birthplace());
+            ps.setString(7, toSave.profession());
+            ps.setString(8, toSave.language());
+            ps.setString(9, encode(toSave.lifeEvents()));
+            ps.setString(10, encode(toSave.personalityTraits()));
+            ps.setString(11, encode(toSave.historicalContext()));
+            ps.setString(12, toSave.photoUrl());
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to create ancestor", e);
+        }
+        return toSave;
+    }
+
+    public List<Ancestor> findAll() {
+        List<Ancestor> out = new ArrayList<>();
+        try (Connection c = connect();
+             Statement s = c.createStatement();
+             ResultSet rs = s.executeQuery("SELECT * FROM ancestors ORDER BY name")) {
+            while (rs.next()) {
+                out.add(map(rs));
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to list ancestors", e);
+        }
+        return out;
+    }
+
+    public Optional<Ancestor> findById(String id) {
+        try (Connection c = connect();
+             PreparedStatement ps = c.prepareStatement("SELECT * FROM ancestors WHERE id = ?")) {
+            ps.setString(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return Optional.of(map(rs));
+                }
+                return Optional.empty();
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to fetch ancestor", e);
+        }
+    }
+
+    public boolean delete(String id) {
+        try (Connection c = connect()) {
+            c.setAutoCommit(false);
+            try (PreparedStatement m = c.prepareStatement("DELETE FROM messages WHERE ancestor_id = ?");
+                 PreparedStatement a = c.prepareStatement("DELETE FROM ancestors WHERE id = ?")) {
+                m.setString(1, id);
+                m.executeUpdate();
+                a.setString(1, id);
+                int n = a.executeUpdate();
+                c.commit();
+                return n > 0;
+            } catch (SQLException e) {
+                c.rollback();
+                throw e;
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to delete ancestor", e);
+        }
+    }
+
+    private Ancestor map(ResultSet rs) throws SQLException {
+        return new Ancestor(
+                rs.getString("id"),
+                rs.getString("name"),
+                rs.getString("relation"),
+                getNullableInt(rs, "birth_year"),
+                getNullableInt(rs, "death_year"),
+                rs.getString("birthplace"),
+                rs.getString("profession"),
+                rs.getString("language"),
+                decode(rs.getString("life_events")),
+                decode(rs.getString("personality_traits")),
+                decode(rs.getString("historical_context")),
+                rs.getString("photo_url")
+        );
+    }
+
+    private static void setNullableInt(PreparedStatement ps, int idx, Integer v) throws SQLException {
+        if (v == null) {
+            ps.setNull(idx, java.sql.Types.INTEGER);
+        } else {
+            ps.setInt(idx, v);
+        }
+    }
+
+    private static Integer getNullableInt(ResultSet rs, String col) throws SQLException {
+        int v = rs.getInt(col);
+        return rs.wasNull() ? null : v;
+    }
+
+    private static String encode(List<String> list) {
+        if (list == null) return null;
+        try {
+            return JSON.writeValueAsString(list);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static List<String> decode(String s) {
+        if (s == null || s.isBlank()) return List.of();
+        try {
+            return JSON.readValue(s, STR_LIST);
+        } catch (Exception e) {
+            return List.of();
+        }
+    }
+}

--- a/server/src/main/java/com/nerw/ancestor/chat/AnthropicClient.java
+++ b/server/src/main/java/com/nerw/ancestor/chat/AnthropicClient.java
@@ -1,0 +1,141 @@
+package com.nerw.ancestor.chat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.function.Consumer;
+
+@Component
+public class AnthropicClient {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final HttpClient http = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(15))
+            .build();
+
+    private final String apiUrl;
+    private final String apiKey;
+    private final String model;
+    private final int maxTokens;
+
+    public AnthropicClient(
+            @Value("${anthropic.api-url}") String apiUrl,
+            @Value("${anthropic.api-key:}") String apiKey,
+            @Value("${anthropic.model}") String model,
+            @Value("${anthropic.max-tokens}") int maxTokens) {
+        this.apiUrl = apiUrl;
+        this.apiKey = apiKey;
+        this.model = model;
+        this.maxTokens = maxTokens;
+    }
+
+    public boolean isConfigured() {
+        return apiKey != null && !apiKey.isBlank();
+    }
+
+    public static class AnthropicException extends RuntimeException {
+        public AnthropicException(String msg) { super(msg); }
+        public AnthropicException(String msg, Throwable t) { super(msg, t); }
+    }
+
+    /**
+     * POSTs to /v1/messages with stream=true and forwards each text delta to onChunk.
+     * Returns the assembled full response text.
+     */
+    public String streamMessage(String systemPrompt, List<Message> history, String userMsg, Consumer<String> onChunk) {
+        if (!isConfigured()) {
+            throw new AnthropicException("ANTHROPIC_API_KEY not configured");
+        }
+
+        ObjectNode body = JSON.createObjectNode();
+        body.put("model", model);
+        body.put("max_tokens", maxTokens);
+        body.put("system", systemPrompt);
+        body.put("stream", true);
+
+        ArrayNode messages = body.putArray("messages");
+        if (history != null) {
+            for (Message m : history) {
+                String role = "ancestor".equals(m.role()) ? "assistant" : "user";
+                ObjectNode msg = messages.addObject();
+                msg.put("role", role);
+                msg.put("content", m.content());
+            }
+        }
+        ObjectNode last = messages.addObject();
+        last.put("role", "user");
+        last.put("content", userMsg);
+
+        String payload;
+        try {
+            payload = JSON.writeValueAsString(body);
+        } catch (Exception e) {
+            throw new AnthropicException("Failed to encode request", e);
+        }
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create(apiUrl + "/v1/messages"))
+                .timeout(Duration.ofSeconds(120))
+                .header("x-api-key", apiKey)
+                .header("anthropic-version", "2023-06-01")
+                .header("content-type", "application/json")
+                .header("accept", "text/event-stream")
+                .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
+                .build();
+
+        StringBuilder full = new StringBuilder();
+        try {
+            HttpResponse<java.io.InputStream> resp = http.send(req, HttpResponse.BodyHandlers.ofInputStream());
+            if (resp.statusCode() / 100 != 2) {
+                String err = new String(resp.body().readAllBytes(), StandardCharsets.UTF_8);
+                throw new AnthropicException("Anthropic API error " + resp.statusCode() + ": " + err);
+            }
+
+            try (BufferedReader r = new BufferedReader(new InputStreamReader(resp.body(), StandardCharsets.UTF_8))) {
+                String line;
+                while ((line = r.readLine()) != null) {
+                    if (!line.startsWith("data:")) continue;
+                    String data = line.substring(5).trim();
+                    if (data.isEmpty() || "[DONE]".equals(data)) continue;
+
+                    JsonNode evt;
+                    try {
+                        evt = JSON.readTree(data);
+                    } catch (Exception parseErr) {
+                        continue;
+                    }
+
+                    String type = evt.path("type").asText("");
+                    if ("content_block_delta".equals(type)) {
+                        String text = evt.path("delta").path("text").asText("");
+                        if (!text.isEmpty()) {
+                            full.append(text);
+                            onChunk.accept(text);
+                        }
+                    } else if ("message_stop".equals(type)) {
+                        break;
+                    }
+                }
+            }
+        } catch (AnthropicException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AnthropicException("Anthropic streaming failed: " + e.getMessage(), e);
+        }
+        return full.toString();
+    }
+}

--- a/server/src/main/java/com/nerw/ancestor/chat/ChatController.java
+++ b/server/src/main/java/com/nerw/ancestor/chat/ChatController.java
@@ -1,0 +1,116 @@
+package com.nerw.ancestor.chat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.nerw.ancestor.ancestor.Ancestor;
+import com.nerw.ancestor.ancestor.AncestorRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+@RestController
+@RequestMapping("/api/chat")
+public class ChatController {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    private final AncestorRepository ancestors;
+    private final MessageRepository messages;
+    private final PersonaPromptBuilder personaBuilder;
+    private final AnthropicClient anthropic;
+    private final ExecutorService streamExecutor =
+            Executors.newCachedThreadPool(r -> {
+                Thread t = new Thread(r, "chat-stream");
+                t.setDaemon(true);
+                return t;
+            });
+
+    public ChatController(AncestorRepository ancestors,
+                          MessageRepository messages,
+                          PersonaPromptBuilder personaBuilder,
+                          AnthropicClient anthropic) {
+        this.ancestors = ancestors;
+        this.messages = messages;
+        this.personaBuilder = personaBuilder;
+        this.anthropic = anthropic;
+    }
+
+    public record ChatRequest(String message) {}
+
+    @PostMapping(value = "/{id}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Object chat(@PathVariable String id, @RequestBody ChatRequest req, HttpServletResponse response) {
+        Optional<Ancestor> found = ancestors.findById(id);
+        if (found.isEmpty()) {
+            return ResponseEntity.status(404)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of("error", "ancestor not found"));
+        }
+        if (!anthropic.isConfigured()) {
+            return ResponseEntity.status(500)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(Map.of("error", "ANTHROPIC_API_KEY not configured"));
+        }
+
+        Ancestor ancestor = found.get();
+        String userMsg = req.message() == null ? "" : req.message();
+
+        response.setHeader("Cache-Control", "no-cache");
+        response.setHeader("X-Accel-Buffering", "no");
+
+        SseEmitter emitter = new SseEmitter(0L);
+        List<Message> history = messages.history(id);
+        messages.append(id, "user", userMsg);
+
+        streamExecutor.submit(() -> {
+            try {
+                String system = personaBuilder.build(ancestor);
+                String full = anthropic.streamMessage(system, history, userMsg, chunk -> {
+                    sendEvent(emitter, Map.of("type", "chunk", "text", chunk));
+                });
+                messages.append(id, "ancestor", full);
+                sendEvent(emitter, Map.of("type", "done"));
+                emitter.complete();
+            } catch (Exception e) {
+                try {
+                    sendEvent(emitter, Map.of("type", "error", "message", e.getMessage() == null ? "stream error" : e.getMessage()));
+                } catch (Exception ignore) {
+                }
+                emitter.completeWithError(e);
+            }
+        });
+
+        return emitter;
+    }
+
+    @GetMapping("/{id}/messages")
+    public ResponseEntity<?> history(@PathVariable String id) {
+        if (ancestors.findById(id).isEmpty()) {
+            return ResponseEntity.status(404).body(Map.of("error", "ancestor not found"));
+        }
+        return ResponseEntity.ok(messages.history(id));
+    }
+
+    private static void sendEvent(SseEmitter emitter, Map<String, ?> payload) {
+        try {
+            String json = JSON.writeValueAsString(payload);
+            emitter.send(SseEmitter.event().data(json, MediaType.APPLICATION_JSON));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/server/src/main/java/com/nerw/ancestor/chat/Message.java
+++ b/server/src/main/java/com/nerw/ancestor/chat/Message.java
@@ -1,0 +1,10 @@
+package com.nerw.ancestor.chat;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record Message(
+        String role,
+        String content,
+        @JsonProperty("created_at") String createdAt
+) {
+}

--- a/server/src/main/java/com/nerw/ancestor/chat/MessageRepository.java
+++ b/server/src/main/java/com/nerw/ancestor/chat/MessageRepository.java
@@ -1,0 +1,54 @@
+package com.nerw.ancestor.chat;
+
+import com.nerw.ancestor.ancestor.AncestorRepository;
+import org.springframework.stereotype.Repository;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+public class MessageRepository {
+
+    private final AncestorRepository ancestors;
+
+    public MessageRepository(AncestorRepository ancestors) {
+        this.ancestors = ancestors;
+    }
+
+    public void append(String ancestorId, String role, String content) {
+        String now = Instant.now().toString();
+        try (Connection c = ancestors.connect();
+             PreparedStatement ps = c.prepareStatement(
+                     "INSERT INTO messages (ancestor_id, role, content, created_at) VALUES (?,?,?,?)")) {
+            ps.setString(1, ancestorId);
+            ps.setString(2, role);
+            ps.setString(3, content);
+            ps.setString(4, now);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to append message", e);
+        }
+    }
+
+    public List<Message> history(String ancestorId) {
+        List<Message> out = new ArrayList<>();
+        try (Connection c = ancestors.connect();
+             PreparedStatement ps = c.prepareStatement(
+                     "SELECT role, content, created_at FROM messages WHERE ancestor_id = ? ORDER BY id ASC")) {
+            ps.setString(1, ancestorId);
+            try (ResultSet rs = ps.executeQuery()) {
+                while (rs.next()) {
+                    out.add(new Message(rs.getString(1), rs.getString(2), rs.getString(3)));
+                }
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to load history", e);
+        }
+        return out;
+    }
+}

--- a/server/src/main/java/com/nerw/ancestor/chat/PersonaPromptBuilder.java
+++ b/server/src/main/java/com/nerw/ancestor/chat/PersonaPromptBuilder.java
@@ -1,0 +1,48 @@
+package com.nerw.ancestor.chat;
+
+import com.nerw.ancestor.ancestor.Ancestor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class PersonaPromptBuilder {
+
+    private static final String TEMPLATE = """
+            You are {name}, born {birth_year} in {birthplace}, died {death_year}.
+            Relation to user: {relation}. Profession: {profession}.
+            Lived through: {historical_context}. Life events: {life_events}.
+            Personality: {personality_traits}.
+            You speak in {language}. Stay strictly in character.
+            Knowledge cutoff = {death_year}. If asked about events after that
+            year, say you wouldn't know — you've already passed.
+            Use period-appropriate vocabulary and worldview.
+            """;
+
+    public String build(Ancestor a) {
+        return TEMPLATE
+                .replace("{name}", nullSafe(a.name()))
+                .replace("{birth_year}", numStr(a.birthYear()))
+                .replace("{birthplace}", nullSafe(a.birthplace()))
+                .replace("{death_year}", numStr(a.deathYear()))
+                .replace("{relation}", nullSafe(a.relation()))
+                .replace("{profession}", nullSafe(a.profession()))
+                .replace("{historical_context}", join(a.historicalContext()))
+                .replace("{life_events}", join(a.lifeEvents()))
+                .replace("{personality_traits}", join(a.personalityTraits()))
+                .replace("{language}", nullSafe(a.language()));
+    }
+
+    private static String nullSafe(String s) {
+        return s == null ? "" : s;
+    }
+
+    private static String numStr(Integer n) {
+        return n == null ? "" : n.toString();
+    }
+
+    private static String join(List<String> items) {
+        if (items == null || items.isEmpty()) return "";
+        return String.join(", ", items);
+    }
+}

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -1,0 +1,15 @@
+server:
+  port: 8080
+
+db:
+  path: ${ANCESTOR_DB_PATH:./data/ancestors.db}
+
+anthropic:
+  api-url: ${ANTHROPIC_API_URL:https://api.anthropic.com}
+  api-key: ${ANTHROPIC_API_KEY:}
+  model: claude-haiku-4-5-20251001
+  max-tokens: 1024
+
+logging:
+  level:
+    org.springframework.web: INFO

--- a/server/src/test/java/com/nerw/ancestor/AncestorRepositoryTest.java
+++ b/server/src/test/java/com/nerw/ancestor/AncestorRepositoryTest.java
@@ -1,0 +1,64 @@
+package com.nerw.ancestor;
+
+import com.nerw.ancestor.ancestor.Ancestor;
+import com.nerw.ancestor.ancestor.AncestorRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class AncestorRepositoryTest {
+
+    private Path dbFile;
+    private AncestorRepository repo;
+
+    @BeforeEach
+    void setup() throws Exception {
+        dbFile = Files.createTempFile("ancestors-test", ".db");
+        Files.deleteIfExists(dbFile);
+        repo = new AncestorRepository(dbFile.toString());
+        repo.init();
+    }
+
+    @AfterEach
+    void cleanup() throws Exception {
+        Files.deleteIfExists(dbFile);
+    }
+
+    @Test
+    void crudSmoke() {
+        Ancestor a = new Ancestor(
+                null, "Babcia Anna", "grandmother", 1910, 1985,
+                "Krakow", "seamstress", "Polish",
+                List.of("WW2 survivor", "moved to Warsaw"),
+                List.of("warm", "stoic"),
+                List.of("WWII", "post-war Poland"),
+                null);
+
+        Ancestor saved = repo.create(a);
+        assertNotNull(saved.id());
+        assertEquals("Babcia Anna", saved.name());
+
+        List<Ancestor> all = repo.findAll();
+        assertEquals(1, all.size());
+
+        Optional<Ancestor> fetched = repo.findById(saved.id());
+        assertTrue(fetched.isPresent());
+        assertEquals("seamstress", fetched.get().profession());
+        assertEquals(2, fetched.get().lifeEvents().size());
+        assertEquals(1910, fetched.get().birthYear());
+
+        assertTrue(repo.delete(saved.id()));
+        assertFalse(repo.findById(saved.id()).isPresent());
+        assertEquals(0, repo.findAll().size());
+    }
+}

--- a/server/src/test/java/com/nerw/ancestor/ChatControllerIT.java
+++ b/server/src/test/java/com/nerw/ancestor/ChatControllerIT.java
@@ -1,0 +1,142 @@
+package com.nerw.ancestor;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.nerw.ancestor.ancestor.Ancestor;
+import com.nerw.ancestor.ancestor.AncestorRepository;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpRequest.BodyPublishers;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class ChatControllerIT {
+
+    private static final WireMockServer wireMock;
+    private static final Path dbPath;
+
+    static {
+        wireMock = new WireMockServer(options().dynamicPort());
+        wireMock.start();
+        try {
+            dbPath = Files.createTempFile("chat-it", ".db");
+            Files.deleteIfExists(dbPath);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    AncestorRepository ancestors;
+
+    @AfterAll
+    static void stop() throws Exception {
+        if (wireMock != null) wireMock.stop();
+        if (dbPath != null) Files.deleteIfExists(dbPath);
+    }
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry reg) {
+        reg.add("anthropic.api-url", () -> "http://localhost:" + wireMock.port());
+        reg.add("anthropic.api-key", () -> "test-key");
+        reg.add("db.path", () -> dbPath.toString());
+    }
+
+    @BeforeEach
+    void resetMocks() {
+        wireMock.resetAll();
+    }
+
+    @Test
+    void streamsChunksAndPersistsHistory() throws Exception {
+        String sseBody = """
+                event: message_start
+                data: {"type":"message_start"}
+
+                event: content_block_delta
+                data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}
+
+                event: content_block_delta
+                data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":", dziecko"}}
+
+                event: message_stop
+                data: {"type":"message_stop"}
+
+                """;
+
+        wireMock.stubFor(post(urlEqualTo("/v1/messages"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("content-type", "text/event-stream")
+                        .withBody(sseBody)));
+
+        Ancestor saved = ancestors.create(new Ancestor(
+                null, "TestAncestor", "grandparent", 1900, 1980,
+                "Town", "teacher", "English",
+                List.of("event1"), List.of("kind"), List.of("WW1"),
+                null));
+
+        HttpClient http = HttpClient.newHttpClient();
+
+        HttpRequest req = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + "/api/chat/" + saved.id()))
+                .header("content-type", "application/json")
+                .POST(BodyPublishers.ofString("{\"message\":\"hi\"}"))
+                .build();
+
+        HttpResponse<String> resp = http.send(req, BodyHandlers.ofString());
+
+        assertEquals(200, resp.statusCode());
+        String contentType = resp.headers().firstValue("Content-Type").orElse("");
+        assertTrue(contentType.contains("text/event-stream"),
+                "Expected text/event-stream, got: " + contentType);
+
+        String body = resp.body();
+        long chunkCount = body.lines().filter(l -> l.contains("\"type\":\"chunk\"")).count();
+        long doneCount = body.lines().filter(l -> l.contains("\"type\":\"done\"")).count();
+        assertTrue(chunkCount >= 1, "Expected at least one chunk event in body:\n" + body);
+        assertEquals(1, doneCount, "Expected exactly one done event in body:\n" + body);
+
+        HttpRequest histReq = HttpRequest.newBuilder()
+                .uri(URI.create("http://localhost:" + port + "/api/chat/" + saved.id() + "/messages"))
+                .GET()
+                .build();
+        HttpResponse<String> histResp = http.send(histReq, BodyHandlers.ofString());
+        assertEquals(200, histResp.statusCode());
+
+        List<Map<String, String>> rows = new ObjectMapper()
+                .readValue(histResp.body(), new TypeReference<>() {});
+        assertEquals(2, rows.size(), "Expected user + ancestor messages, got: " + histResp.body());
+        assertEquals("user", rows.get(0).get("role"));
+        assertEquals("ancestor", rows.get(1).get("role"));
+        assertEquals("hi", rows.get(0).get("content"));
+        assertTrue(rows.get(1).get("content").contains("Hello"),
+                "Ancestor reply should contain streamed text, got: " + rows.get(1).get("content"));
+    }
+}

--- a/server/src/test/java/com/nerw/ancestor/PersonaPromptBuilderTest.java
+++ b/server/src/test/java/com/nerw/ancestor/PersonaPromptBuilderTest.java
@@ -1,0 +1,43 @@
+package com.nerw.ancestor;
+
+import com.nerw.ancestor.ancestor.Ancestor;
+import com.nerw.ancestor.chat.PersonaPromptBuilder;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PersonaPromptBuilderTest {
+
+    private final PersonaPromptBuilder builder = new PersonaPromptBuilder();
+
+    @Test
+    void allPlaceholdersReplaced() {
+        Ancestor a = new Ancestor(
+                "id-1", "Dziadek Jan", "grandfather", 1920, 1995,
+                "Lublin", "carpenter", "Polish",
+                List.of("WW2", "rebuilt town"),
+                List.of("patient", "wise"),
+                List.of("WWII", "communism", "Solidarity"),
+                null);
+
+        String prompt = builder.build(a);
+
+        Pattern leftover = Pattern.compile("\\{[a-z_]+\\}");
+        assertFalse(leftover.matcher(prompt).find(),
+                "Prompt still contains unresolved placeholders: " + prompt);
+
+        assertTrue(prompt.contains("Dziadek Jan"));
+        assertTrue(prompt.contains("1920"));
+        assertTrue(prompt.contains("1995"));
+        assertTrue(prompt.contains("Lublin"));
+        assertTrue(prompt.contains("carpenter"));
+        assertTrue(prompt.contains("WWII, communism, Solidarity"));
+        assertTrue(prompt.contains("patient, wise"));
+        assertTrue(prompt.contains("Polish"));
+        assertTrue(prompt.contains("Knowledge cutoff = 1995"));
+    }
+}


### PR DESCRIPTION
## Summary
- Java 21 + Spring Boot 3.3 + SQLite JDBC backend per ADR-0001
- REST CRUD over `/api/ancestors`, SSE chat over `/api/chat/{id}`
- `PersonaPromptBuilder` reproduces the system prompt verbatim from `api/spec.md`
- Server boots without `ANTHROPIC_API_KEY`; CRUD works, only `/api/chat/{id}` returns 500 with `{ "error": "ANTHROPIC_API_KEY not configured" }` until configured

## Layout
- `server/pom.xml` — `finalName=ancestor-chat`, Spring Boot starter, sqlite-jdbc 3.46.1.0, wiremock-standalone 3.9.2 (test scope)
- `server/src/main/java/com/nerw/ancestor/`
  - `AncestorServer.java` — `@SpringBootApplication`
  - `ancestor/` — `Ancestor` record, `AncestorRepository` (raw SQLite JDBC), `AncestorController` REST CRUD
  - `chat/` — `Message` record, `MessageRepository`, `PersonaPromptBuilder`, `AnthropicClient` (java.net.http SSE), `ChatController` (SSE emitter)
- `server/src/main/resources/application.yml` — `server.port=8080`, `db.path=${ANCESTOR_DB_PATH:./data/ancestors.db}`

## Anthropic streaming
`AnthropicClient.streamMessage` POSTs `model=claude-haiku-4-5-20251001` with `stream=true` to `${anthropic.api-url}/v1/messages`, parses SSE `content_block_delta` events, forwards `delta.text` to a `Consumer<String>`, and returns the assembled full text. `ChatController` wraps each chunk as `{ "type":"chunk", "text":... }`, sends `{ "type":"done" }` on `message_stop`, and persists user + final ancestor message to `messages`.

## Tests (`mvn test` green — 3/3)
- `AncestorRepositoryTest` — CRUD smoke against a temp SQLite file
- `PersonaPromptBuilderTest` — asserts no `{placeholder}` left in rendered prompt and all fields present
- `ChatControllerIT` — `@SpringBootTest` on a random port. WireMock-stubbed Anthropic returns a canned SSE body with two `content_block_delta` events and a `message_stop`. Asserts:
  - `Content-Type: text/event-stream`
  - body has ≥1 `{"type":"chunk"}` and exactly 1 `{"type":"done"}`
  - `GET /api/chat/{id}/messages` returns 2 rows: `user` then `ancestor`

Surefire `<includes>` is set to pick up both `*Test.java` and `*IT.java` so the integration test runs under `mvn test`.

## Notes / deviations
- WireMock 3.x lives at `org.wiremock:wiremock-standalone:3.9.2` (the task referenced the old `com.github.tomakehurst` groupId, which only ships 2.x). Java imports in test code remain `com.github.tomakehurst.wiremock.*`.

## Build
```
cd server && mvn -B package
# → server/target/ancestor-chat.jar (executable Spring Boot fat jar)
```

Closes #1