### PR TITLE
test(e2e): Playwright happy-path for ancestor chat

### DIFF
--- a/e2e/.env.example
+++ b/e2e/.env.example
@@ -1,0 +1,6 @@
+# Force server into mocked Anthropic mode for deterministic E2E.
+# Server PR #2 must honor this flag (see e2e/README.md).
+MOCK_ANTHROPIC=true
+
+# Override default base URL if running stack on non-default host/port.
+# BASE_URL=http://localhost:80

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+.env
+playwright-report/
+test-results/
+data-e2e/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,60 @@
+# Ancestor Chat — E2E
+
+Playwright suite that drives the full stack (nginx → React → Spring server → SQLite) end-to-end.
+
+## Prerequisites
+
+- Docker + Docker Compose
+- Node 20+
+- Server PR #2, web PR #4, docker PR #3 merged (or rebased onto this branch)
+
+## Mocking Anthropic
+
+E2E must not hit the real Anthropic API. The override compose file sets `MOCK_ANTHROPIC=true`:
+
+```
+e2e/docker/docker-compose.test.yml → server.environment.MOCK_ANTHROPIC=true
+```
+
+**Server contract (must be honored by PR #2):** when `MOCK_ANTHROPIC=true`, `AnthropicClient.streamChat` returns canned SSE chunks (e.g. a fixed apologetic line) and never opens an HTTP connection to `api.anthropic.com`. A comment has been filed on PR #2 requesting this flag.
+
+If PR #2 ships without `MOCK_ANTHROPIC` support, you have two options:
+
+1. **Demo path** — provide a real `ANTHROPIC_API_KEY` in `.env` and skip E2E gating in CI. The test will still pass against live Anthropic but is non-deterministic and costs tokens. Mark the workflow as `continue-on-error` until the flag lands.
+2. **Stub sidecar (not implemented here)** — add an `httpbin`-style mock container at `api.anthropic.com` via compose `extra_hosts`. Avoided because nginx-layer mocking of streaming SSE is fragile.
+
+Default: option 1 until the server flag lands.
+
+## Run
+
+```bash
+cd e2e
+cp .env.example .env
+npm ci
+npx playwright install --with-deps chromium
+
+# from repo root:
+docker compose -f docker-compose.yml -f e2e/docker/docker-compose.test.yml up -d --build
+
+cd e2e
+npm test
+
+# tear down:
+cd ..
+docker compose -f docker-compose.yml -f e2e/docker/docker-compose.test.yml down -v
+```
+
+## What it covers
+
+`tests/ancestor-chat.spec.ts` — single happy-path:
+
+1. Open `/`
+2. Click `+ Add`, fill form (name "Бабушка Алла", relation "бабушка", birth 1920, death 1995, birthplace "Малешев", language "ru", life event "пережила войну")
+3. Submit, assert redirect to `/chat/{id}`
+4. Send "Расскажи о войне"
+5. Assert ancestor reply renders with non-empty text
+6. Assert `GET /api/chat/{id}/messages` returns ≥ 2 rows
+
+## CI notes
+
+Until `MOCK_ANTHROPIC` lands on the server, gate this workflow with `continue-on-error: true` or scope it to manual demo runs. The bring-up costs ~60-90s for first build (Maven + npm + nginx).

--- a/e2e/docker/docker-compose.test.yml
+++ b/e2e/docker/docker-compose.test.yml
@@ -1,0 +1,17 @@
+# Override stacked on top of root docker-compose.yml.
+# Usage:
+#   docker compose -f docker-compose.yml -f e2e/docker/docker-compose.test.yml up -d --build
+#
+# Adds MOCK_ANTHROPIC=true so the server returns canned SSE chunks instead of
+# calling the real Anthropic API. Requires server PR #2 to honor MOCK_ANTHROPIC
+# (tracked via comment on PR #2). Until then, the demo flow falls back to the
+# real ANTHROPIC_API_KEY path — see e2e/README.md.
+
+services:
+  server:
+    environment:
+      MOCK_ANTHROPIC: "true"
+      ANTHROPIC_API_KEY: "mock-not-used"
+      ANCESTOR_DB_PATH: /data/ancestors.db
+    volumes:
+      - ./data-e2e:/data

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ancestor-chat-e2e",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.49.0",
+    "dotenv": "^16.4.7"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from "@playwright/test";
+import "dotenv/config";
+
+const BASE_URL = process.env.BASE_URL ?? "http://localhost:80";
+
+export default defineConfig({
+  testDir: "./tests",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: 1,
+  reporter: [["list"], ["html", { open: "never" }]],
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: BASE_URL,
+    headless: true,
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    { name: "chromium", use: { ...devices["Desktop Chrome"] } },
+  ],
+});

--- a/e2e/tests/ancestor-chat.spec.ts
+++ b/e2e/tests/ancestor-chat.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+
+test("user can add ancestor and chat", async ({ page, request, baseURL }) => {
+  await page.goto("/");
+
+  await page.getByRole("link", { name: /\+\s*Add/i }).click();
+  await expect(page).toHaveURL(/\/add$/);
+
+  await page.getByLabel(/name/i).fill("Бабушка Алла");
+  await page.getByLabel(/relation/i).fill("бабушка");
+  await page.getByLabel(/birth/i).fill("1920");
+  await page.getByLabel(/death/i).fill("1995");
+  await page.getByLabel(/birthplace/i).fill("Малешев");
+  await page.getByLabel(/language/i).fill("ru");
+
+  const lifeEvents = page.getByLabel(/life.?events?/i);
+  await lifeEvents.fill("пережила войну");
+
+  await Promise.all([
+    page.waitForURL(/\/chat\/[^/]+$/),
+    page.getByRole("button", { name: /save|create|submit/i }).click(),
+  ]);
+
+  const chatId = page.url().split("/chat/")[1];
+  expect(chatId).toBeTruthy();
+
+  const input = page.getByRole("textbox").last();
+  await input.fill("Расскажи о войне");
+  await input.press("Enter");
+
+  const ancestorMessage = page
+    .locator('[data-role="ancestor"], .msg-ancestor, [data-author="ancestor"]')
+    .first();
+  await expect(ancestorMessage).toBeVisible({ timeout: 30_000 });
+  await expect(ancestorMessage).not.toHaveText("");
+
+  const resp = await request.get(`${baseURL}/api/chat/${chatId}/messages`);
+  expect(resp.status()).toBe(200);
+  const messages = await resp.json();
+  expect(Array.isArray(messages)).toBe(true);
+  expect(messages.length).toBeGreaterThanOrEqual(2);
+});


### PR DESCRIPTION
## Summary
- Adds isolated `e2e/` workspace with Playwright (chromium, headless) targeting the full docker-compose stack at `http://localhost:80`.
- Single happy-path: add ancestor (Бабушка Алла, ru) → chat → assert ancestor reply + 2 rows in `/api/chat/{id}/messages`.
- `e2e/docker/docker-compose.test.yml` layers `MOCK_ANTHROPIC=true` onto the root compose so SSE responses are deterministic.

## Server contract
This PR assumes server PR #2 honors `MOCK_ANTHROPIC=true` (canned SSE chunks, no real Anthropic call). A comment has been filed on PR #2 requesting the flag. If it ships without it, README documents the demo-path fallback (real `ANTHROPIC_API_KEY`, CI gating skipped).

## Layout
```
e2e/
  package.json            (@playwright/test, dotenv)
  playwright.config.ts    baseURL http://localhost:80, no webServer
  .env.example            MOCK_ANTHROPIC=true
  .gitignore
  README.md               run + mock-flag contract
  docker/docker-compose.test.yml
  tests/ancestor-chat.spec.ts
```

## Test plan
- [ ] After PR #2/#3/#4 land: `docker compose -f docker-compose.yml -f e2e/docker/docker-compose.test.yml up -d --build`
- [ ] `cd e2e && npm ci && npx playwright install --with-deps chromium && npm test`
- [ ] Tear down with `docker compose ... down -v`
- [ ] Until then: spec is unrunnable (no upstream stack on master). Locator strings are best-effort against PR #4 markup; expect minor selector tweaks once stack is bootable.

## Notes for reviewer
- Locators target labels (`/name/i`, `/relation/i`, ...) and a few likely class/role hooks for the ancestor message bubble (`[data-role="ancestor"], .msg-ancestor, [data-author="ancestor"]`). These need confirmation against the actual web build — consider adding `data-testid` hooks to PR #4.
- Single test by design — task said "ONE clean test that exercises full flow."

🤖 Generated with [Claude Code](https://claude.com/claude-code)